### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 This repository provides a Python wrapper for the YggTorrent website and an MCP (Model Context Protocol) server to interact with it programmatically. This allows for easy integration of YggTorrent functionalities into other applications or services.
 
+<a href="https://glama.ai/mcp/servers/@philogicae/ygg-torrent-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@philogicae/ygg-torrent-mcp/badge" alt="YggTorrent Server MCP server" />
+</a>
+
 > [How to use it with MCP Clients](#via-mcp-clients)
 
 ## Table of Contents


### PR DESCRIPTION
This PR adds a badge for the [YggTorrent MCP Server](https://glama.ai/mcp/servers/@philogicae/ygg-torrent-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@philogicae/ygg-torrent-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@philogicae/ygg-torrent-mcp/badge" alt="YggTorrent Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.